### PR TITLE
Issue #3: VZCode View Container Contribution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js",
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,24 @@
     "plots",
     "real-time"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:vzcode.helloWorld",
+    "onCommand:vzcode.showVersion"
+  ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands": []
+    "commands": [
+      {
+        "command": "vzcode.helloWorld",
+        "title": "VZCode: Hello World",
+        "category": "VZCode"
+      },
+      {
+        "command": "vzcode.showVersion",
+        "title": "VZCode: Show Version",
+        "category": "VZCode"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,15 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "vzcode",
+          "title": "VZCode",
+          "icon": "resources/vzcode-icon.svg"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "vzcode.helloWorld",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
         }
       ]
     },
+    "views": {
+      "vzcode": [
+        {
+          "id": "vzcode.dashboardsView",
+          "name": "Dashboards"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "vzcode.helloWorld",

--- a/resources/vzcode-icon.svg
+++ b/resources/vzcode-icon.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- VZ monogram with data visualization theme -->
+  <path d="M3 4 L9 4 L3 12 L9 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11 4 L11 12 L17 4 L17 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Data visualization elements -->
+  <circle cx="6" cy="18" r="1.5" fill="currentColor"/>
+  <circle cx="12" cy="16" r="1.5" fill="currentColor"/>
+  <circle cx="18" cy="19" r="1.5" fill="currentColor"/>
+  <path d="M6 18 L12 16 L18 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,41 @@
 import * as vscode from 'vscode';
+import { logger } from './utils/logger';
 
 /**
  * Called when the extension is activated.
  * The extension is activated the very first time a command is executed.
  */
-export function activate(_context: vscode.ExtensionContext): void {
-  console.log('VZCode extension is now active');
+export function activate(context: vscode.ExtensionContext): void {
+  logger.info('Extension is now active');
+  logger.debug('Extension context:', { extensionPath: context.extensionPath });
 
-  // Extension activation logic will be added here
-  // See: https://github.com/thatdspguy/vzcode/issues for roadmap
+  // Register commands in the vzcode namespace
+  registerCommands(context);
+
+  logger.info('All commands registered successfully');
+}
+
+/**
+ * Register all VZCode commands with the VS Code command palette.
+ */
+function registerCommands(context: vscode.ExtensionContext): void {
+  // vzcode.helloWorld - Simple test command
+  const helloWorldCommand = vscode.commands.registerCommand('vzcode.helloWorld', () => {
+    logger.info('Hello World command executed');
+    void vscode.window.showInformationMessage('Hello from VZCode!');
+  });
+  context.subscriptions.push(helloWorldCommand);
+
+  // vzcode.showVersion - Display extension version
+  const showVersionCommand = vscode.commands.registerCommand('vzcode.showVersion', () => {
+    const extension = vscode.extensions.getExtension('thatdspguy.vzcode');
+    const version: string = (extension?.packageJSON as { version?: string } | undefined)?.version ?? 'unknown';
+    logger.info('Show Version command executed, version:', version);
+    void vscode.window.showInformationMessage(`VZCode version ${version}`);
+  });
+  context.subscriptions.push(showVersionCommand);
+
+  logger.debug('Registered commands: vzcode.helloWorld, vzcode.showVersion');
 }
 
 /**
@@ -16,5 +43,6 @@ export function activate(_context: vscode.ExtensionContext): void {
  * Clean up any resources here.
  */
 export function deactivate(): void {
-  console.log('VZCode extension is now deactivated');
+  logger.info('Extension is now deactivated');
+  // Note: Disposables registered in context.subscriptions are automatically disposed by VS Code
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,8 @@ function registerCommands(context: vscode.ExtensionContext): void {
   // vzcode.showVersion - Display extension version
   const showVersionCommand = vscode.commands.registerCommand('vzcode.showVersion', () => {
     const extension = vscode.extensions.getExtension('thatdspguy.vzcode');
-    const version: string = (extension?.packageJSON as { version?: string } | undefined)?.version ?? 'unknown';
+    const version: string =
+      (extension?.packageJSON as { version?: string } | undefined)?.version ?? 'unknown';
     logger.info('Show Version command executed, version:', version);
     void vscode.window.showInformationMessage(`VZCode version ${version}`);
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { logger } from './utils/logger';
+import { DashboardsViewProvider } from './views/dashboardsView';
 
 /**
  * Called when the extension is activated.
@@ -9,10 +10,28 @@ export function activate(context: vscode.ExtensionContext): void {
   logger.info('Extension is now active');
   logger.debug('Extension context:', { extensionPath: context.extensionPath });
 
+  // Register view providers
+  registerViews(context);
+
   // Register commands in the vzcode namespace
   registerCommands(context);
 
   logger.info('All commands registered successfully');
+}
+
+/**
+ * Register all VZCode view providers.
+ */
+function registerViews(context: vscode.ExtensionContext): void {
+  // Register Dashboards view
+  const dashboardsViewProvider = new DashboardsViewProvider();
+  const dashboardsView = vscode.window.registerTreeDataProvider(
+    'vzcode.dashboardsView',
+    dashboardsViewProvider
+  );
+  context.subscriptions.push(dashboardsView);
+
+  logger.debug('Registered view: vzcode.dashboardsView');
 }
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,72 @@
+/**
+ * Logging utility for the VZCode extension.
+ * Provides consistent, prefixed logging across the extension.
+ */
+
+export enum LogLevel {
+  Debug = 0,
+  Info = 1,
+  Warn = 2,
+  Error = 3,
+}
+
+class Logger {
+  private static instance: Logger;
+  private logLevel: LogLevel = LogLevel.Info;
+  private readonly prefix = '[VZCode]';
+
+  private constructor() {}
+
+  public static getInstance(): Logger {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
+    }
+    return Logger.instance;
+  }
+
+  /**
+   * Set the minimum log level to output.
+   */
+  public setLogLevel(level: LogLevel): void {
+    this.logLevel = level;
+  }
+
+  /**
+   * Log a debug message (lowest priority).
+   */
+  public debug(message: string, ...args: unknown[]): void {
+    if (this.logLevel <= LogLevel.Debug) {
+      console.debug(`${this.prefix} [DEBUG]`, message, ...args);
+    }
+  }
+
+  /**
+   * Log an informational message.
+   */
+  public info(message: string, ...args: unknown[]): void {
+    if (this.logLevel <= LogLevel.Info) {
+      console.log(`${this.prefix} [INFO]`, message, ...args);
+    }
+  }
+
+  /**
+   * Log a warning message.
+   */
+  public warn(message: string, ...args: unknown[]): void {
+    if (this.logLevel <= LogLevel.Warn) {
+      console.warn(`${this.prefix} [WARN]`, message, ...args);
+    }
+  }
+
+  /**
+   * Log an error message (highest priority).
+   */
+  public error(message: string, ...args: unknown[]): void {
+    if (this.logLevel <= LogLevel.Error) {
+      console.error(`${this.prefix} [ERROR]`, message, ...args);
+    }
+  }
+}
+
+// Export a singleton instance
+export const logger = Logger.getInstance();

--- a/src/views/dashboardsView.ts
+++ b/src/views/dashboardsView.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+
+/**
+ * Tree data provider for the Dashboards view
+ */
+export class DashboardsViewProvider implements vscode.TreeDataProvider<DashboardItem> {
+	private _onDidChangeTreeData: vscode.EventEmitter<DashboardItem | undefined | null | void> = new vscode.EventEmitter<DashboardItem | undefined | null | void>();
+	readonly onDidChangeTreeData: vscode.Event<DashboardItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+	constructor() {}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
+
+	getTreeItem(element: DashboardItem): vscode.TreeItem {
+		return element;
+	}
+
+	getChildren(element?: DashboardItem): Thenable<DashboardItem[]> {
+		if (element) {
+			// No children for now
+			return Promise.resolve([]);
+		} else {
+			// Root level - placeholder item
+			return Promise.resolve([
+				new DashboardItem(
+					'No dashboards yet',
+					vscode.TreeItemCollapsibleState.None,
+					'Create your first dashboard to get started'
+				)
+			]);
+		}
+	}
+}
+
+/**
+ * Represents an item in the Dashboards tree view
+ */
+export class DashboardItem extends vscode.TreeItem {
+	constructor(
+		public readonly label: string,
+		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+		public readonly tooltip?: string
+	) {
+		super(label, collapsibleState);
+		this.tooltip = tooltip;
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements the VZCode view container contribution as specified in issue #3.

## Changes

- Added `viewsContainers` contribution to `package.json` for Activity Bar placement
- Added `views` contribution with a Dashboards view to make the container visible
- Created custom SVG icon (`resources/vzcode-icon.svg`) for the VZCode view container
- Implemented `DashboardsViewProvider` with placeholder content
- Container ID: `vzcode`
- Default placement: Activity Bar
- Container can be moved to Panel (VS Code native functionality)

## Implementation Details

The view container is configured with:
- **ID**: `vzcode` - used as the identifier for the view container
- **Title**: "VZCode" - displayed in the UI
- **Icon**: Custom SVG icon with "VZ" monogram and data visualization elements
- **Placement**: Activity Bar (with Panel move support built-in)

**Important Note**: View containers in VS Code only appear in the UI when they contain at least one view. This PR includes a placeholder Dashboards view that displays "No dashboards yet" to make the container visible.

## Files Changed

- [package.json](package.json) - Added viewsContainers and views contributions
- [resources/vzcode-icon.svg](resources/vzcode-icon.svg) - Custom icon for Activity Bar
- [src/extension.ts](src/extension.ts) - Register view provider on activation
- [src/views/dashboardsView.ts](src/views/dashboardsView.ts) - TreeDataProvider for Dashboards view

## Testing

### Manual Verification Steps

1. Install/run the extension in Extension Development Host (F5)
2. ✅ Verify VZCode icon appears in Activity Bar
3. ✅ Click the icon to open the view and see "No dashboards yet" placeholder
4. ✅ Right-click the icon and verify "Move to Panel" option works
5. ✅ Verify the view container can be moved back to Activity Bar

### Build Verification

- ✅ Compilation: `npm run compile` - passes
- ✅ Linting: `npm run lint` - passes (TypeScript version warning only)
- ✅ No package.json validation errors

## Acceptance Criteria Met

- [x] VZCode icon appears in Activity Bar
- [x] Container can be moved to Panel
- [x] `package.json` contribution entries added

## Dependencies

Closes #3
Depends on: #2 (Extension Activation & Lifecycle)

## Notes

- The icon design uses a "VZ" monogram with data visualization elements (dots and connecting lines) to represent the extension's purpose
- VS Code automatically handles the ability to move view containers between Activity Bar and Panel
- A placeholder view (Dashboards) is included because view containers require at least one view to be visible in the UI
- Future PRs will add actual dashboard functionality and additional views within this container
